### PR TITLE
Make compatible with Puppet 3.8.5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 class nvidia (
-	Integer[1] $version = 352
+	$version = 352
 ) {
 
 	case $::kernel {

--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -1,5 +1,5 @@
 class nvidia::linux (
-	Integer[1] $driver_version,
+	$driver_version,
 ) {
 
 	case $::operatingsystem {

--- a/manifests/linux/ubuntu.pp
+++ b/manifests/linux/ubuntu.pp
@@ -1,5 +1,5 @@
 class nvidia::linux::ubuntu (
-	Integer[1] $driver_version,
+	$driver_version,
 ) {
 	$package_name = "nvidia-${driver_version}"
 

--- a/manifests/linux/ubuntu.pp
+++ b/manifests/linux/ubuntu.pp
@@ -6,7 +6,7 @@ class nvidia::linux::ubuntu (
 	# Ensure that our custom fact can run
 	ensure_resource('package', 'pciutils', {'ensure' => 'present' })
 
-	if $nvidiagfx {
+	if str2bool("$nvidiagfx") {
 		include apt
 
 		apt::ppa { 'ppa:graphics-drivers/ppa':
@@ -22,6 +22,11 @@ class nvidia::linux::ubuntu (
 		ensure_resource( 'package', $package_name, {
 			'ensure' => 'present',
 			require => Class['apt::update']
+		})
+	}
+	else {
+		ensure_resource( 'package', $package_name, {
+			'ensure' => 'purged',
 		})
 	}
 }


### PR DESCRIPTION
Not sure if you are interested in this. Ubuntu 16.04 LTS comes by default with Puppet 3.8.5. I prefer having your module compatible with that version until the next LTS comes out.